### PR TITLE
refactor: Use main() and FastAPI lifespan for server.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+*.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Memoria Project
+
+This project implements Memoria, a system for storing and recalling information, with an AI agent interface.
+
+## Running the REST Server
+
+This server provides a REST API for sending events to Memoria.
+
+### Prerequisites
+
+- Python 3.x
+- Pip
+
+### Installation
+
+1.  Clone the repository (if you haven't already).
+2.  Navigate to the project directory.
+3.  Install the required dependencies:
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+### Running the Server
+
+To run the FastAPI server, you have two main options:
+
+1.  **Using Uvicorn (recommended for development with auto-reload):**
+    ```bash
+    uvicorn server:app --reload
+    ```
+    -   `server:app` refers to the `app` instance of FastAPI in the `server.py` file.
+    -   `--reload` enables auto-reloading when code changes are detected.
+
+2.  **Directly executing the Python script:**
+    ```bash
+    python server.py
+    ```
+    -   This method will run the server using the Uvicorn settings specified within the script (e.g., host and port).
+
+The server will typically be available at `http://127.0.0.1:8000`. You can access the root endpoint at `http://127.0.0.1:8000/` to check if it's running, and the API documentation (Swagger UI) at `http://127.0.0.1:8000/docs`.
+
+### API Endpoints
+
+-   **POST /events/**: Send an event to Memoria.
+    -   **Request Body**:
+        ```json
+        {
+            "prompt": "Your event description or query",
+            "prev": null // or an integer ID of a previous memory
+        }
+        ```
+    -   **Response**: Returns a JSON object with the processing result, including the ID of the new memory.
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 sqlite-vec
 numpy
 fastembed-gpu
+fastapi
+uvicorn[standard]

--- a/server.py
+++ b/server.py
@@ -1,0 +1,75 @@
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+from typing import Optional
+from contextlib import asynccontextmanager
+
+from memoria import Database, Memoria # Assuming memoria.py is in the same directory
+
+# Configuration (can remain global or be moved into lifespan/create_app if preferred)
+DATABASE_PATH = "memoria.db"
+FILE_PATH = "files"
+
+class EventPayload(BaseModel):
+    prompt: str
+    prev: Optional[int] = None
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup logic
+    print("Starting up server...")
+    try:
+        database = Database(db_path=DATABASE_PATH, file_path=FILE_PATH)
+        database.__enter__()  # Setup connection and schema
+        app.state.db = database
+        app.state.memoria_instance = Memoria(database)
+        print(f"Database and Memoria initialized successfully using {DATABASE_PATH}")
+    except Exception as e:
+        print(f"Error initializing Database or Memoria during startup: {e}")
+        app.state.db = None
+        app.state.memoria_instance = None
+    
+    yield  # The application runs while the context manager is active
+    
+    # Shutdown logic
+    print("Shutting down server...")
+    if hasattr(app.state, 'db') and app.state.db is not None:
+        try:
+            app.state.db.__exit__(None, None, None)  # Close connection
+            print("Database connection closed successfully.")
+        except Exception as e:
+            print(f"Error closing database connection: {e}")
+
+def create_app():
+    app = FastAPI(lifespan=lifespan)
+
+    @app.post("/events/")
+    async def create_event(payload: EventPayload, request: Request):
+        if not hasattr(request.app.state, 'memoria_instance') or \
+           request.app.state.memoria_instance is None or \
+           not hasattr(request.app.state, 'db') or \
+           request.app.state.db is None:
+            # This check might be redundant if startup guarantees these or exits
+            raise HTTPException(status_code=503, detail="Memoria service is not initialized properly.")
+        
+        memoria_instance = request.app.state.memoria_instance
+        
+        try:
+            result = await memoria_instance.process(prev=payload.prev, prompt=payload.prompt)
+            return result
+        except Exception as e:
+            print(f"Error processing event: {e}") # Basic logging
+            raise HTTPException(status_code=500, detail=f"Failed to process event: {str(e)}")
+
+    @app.get("/")
+    async def root():
+        return {"message": "Memoria REST server is running."}
+        
+    return app
+
+# Create the app instance for uvicorn discovery (e.g., uvicorn server:app)
+app = create_app()
+
+if __name__ == "__main__":
+    # This allows running the server with 'python server.py'
+    uvicorn.run(app, host="127.0.0.1", port=8000)


### PR DESCRIPTION
I've refactored `server.py` to:
- Utilize FastAPI's lifespan context manager for robust database resource initialization and teardown. This ensures the database connection is properly opened on startup and closed on shutdown.
- Structure the application setup within a `create_app()` factory function.
- Enable direct execution via `python server.py` by adding an `if __name__ == "__main__":` block that calls `uvicorn.run()`.
- The global `app` instance is still created for compatibility with `uvicorn server:app`.

I've also updated `README.md` to include `python server.py` as an alternative method for running the server.